### PR TITLE
FIX Quote the reserved "%" indicator to avoid ParseException

### DIFF
--- a/_config/twitter.yml
+++ b/_config/twitter.yml
@@ -5,7 +5,7 @@ SilverStripe\Core\Injector:
   TractorCow\Twitter\Services\TwitterService:
     class: TractorCow\Twitter\Services\CachedTwitterService
     constructor:
-      - %$WebTwitterService
+      - '%$WebTwitterService'
   TractorCow\Twitter\Services\WebTwitterService:
     class: TractorCow\Twitter\Services\TwitterService
   Psr\SimpleCache\CacheInterface.cachedTwitterService:
@@ -14,7 +14,7 @@ SilverStripe\Core\Injector:
       namespace: 'cachedTwitterService'
 TractorCow\Twitter\Extensions\TwitterExtension:
   dependencies:
-    TwitterService: %$TractorCow\Twitter\Services\TwitterService
+    TwitterService: '%$TractorCow\Twitter\Services\TwitterService'
 PageController:
   extensions:
     - TractorCow\Twitter\Extensions\TwitterExtension


### PR DESCRIPTION
Not sure you're maintaining this anymore - feel free to close this if not.

After updating to Silverstripe 4.10 the unquoted strings were causing a `Symfony\Component\Yaml\Exception\ParseException`:
> Uncaught `Symfony\Component\Yaml\Exception\ParseException`: The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 5 (near "- %$WebTwitterService").